### PR TITLE
fix(gpio): Fix typo and correct return logic.

### DIFF
--- a/coresdk/src/backend/gpio_driver.cpp
+++ b/coresdk/src/backend/gpio_driver.cpp
@@ -25,10 +25,10 @@ namespace splashkit_lib
                 if (pi < 0)
                 {
                         cout << "gpio_init() must be called before any other GPIO functions" << endl;
-                        return true;
+                        return false; 
                 }
                 else
-                        return false;
+                        return true;
         }
 
         // Initialize the GPIO library

--- a/coresdk/src/coresdk/raspi_gpio.cpp
+++ b/coresdk/src/coresdk/raspi_gpio.cpp
@@ -88,7 +88,7 @@ namespace splashkit_lib
     // Write a value to the given pin
     void raspi_write(pins pin, pin_values value)
     {
-#ifdef RASPBERRY_PIv
+#ifdef RASPBERRY_PI
         int bcmPin = boardToBCM(pin);
         if (bcmPin == -1)
         {


### PR DESCRIPTION
## Description

When the project is compiled from the projects folder, as per CONTRIBUTING.md and then the GPIO tests from `./sktest` are run it results in errors.

These errors are due to a typo in `raspi_gpio.cpp` and an error in the logic of `check_pi()` in `gpio_driver.cpp`.

`check_pi` return true only when `pigpio_start` has returned a negative value, which indicates an error. Thus, its use later on to in `sk_gpio_read` means that pin readings are only attempted on non-compatible boards.

Fixes [#167](https://github.com/splashkit/splashkit-core/issues/167)

## Type of change

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  This change requires a documentation update

## How Has This Been Tested?

`sktest` was rerun after the changes, and the tests behave as expected.

## Checklist

- [x]  My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [x]  My changes generate no new warnings
- [x]  I have requested a review from Aditya Parmar on the Pull Request